### PR TITLE
fix: increase HTTP response buffer limit for large deck exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ graphify-out/
 .graphify_*.json
 .graphify_*.txt
 typescript/
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ graphify-out/
 .graphify_*.json
 .graphify_*.txt
 typescript/
-out/

--- a/src/anki/client.rs
+++ b/src/anki/client.rs
@@ -14,6 +14,7 @@ pub fn anki_quote(s: &str) -> String {
     format!("\"{escaped}\"")
 }
 const API_VERSION: u8 = 6;
+const MAX_RESPONSE_BODY: u64 = u64::MAX;
 
 pub struct AnkiClient {
     url: String,
@@ -61,6 +62,8 @@ impl AnkiClient {
 
         let response: AnkiResponse<R> = http_response
             .body_mut()
+            .with_config()
+            .limit(MAX_RESPONSE_BODY)
             .read_json()
             .map_err(AnkiConnectError::Decode)?;
 
@@ -108,6 +111,8 @@ impl AnkiClient {
             })?;
         let response: ErrorOnly = http_response
             .body_mut()
+            .with_config()
+            .limit(MAX_RESPONSE_BODY)
             .read_json()
             .map_err(AnkiConnectError::Decode)?;
         if let Some(err) = response.error {


### PR DESCRIPTION
ureq applies a default 10MB cap to response bodies, which causes `read_json` to fail with a size-limit error on large AnkiConnect responses (e.g. `export` over big decks). Call `.with_config().limit(u64::MAX)` on both request paths to lift the cap.

Also ignore `out/` in .gitignore.

Note: just check currently fails due to unrelated pre-existing clippy warnings in src/generate/*.